### PR TITLE
Drop coveralls; Move codeclimate to separate build

### DIFF
--- a/.github/workflows/build-ci-target.yml
+++ b/.github/workflows/build-ci-target.yml
@@ -1,0 +1,63 @@
+name: PayPay PHP SDK Upload CI Results
+on:
+  workflow_run:
+    workflows: ["PayPay Java SDK CI"]
+    types: ["completed"]
+jobs:
+  upload-codeclimate:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Clone PR branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch }}
+
+    - name: Download codeclimate reporter
+      run: |
+           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ../cc-test-reporter && chmod +x ../cc-test-reporter
+
+    - name: codeclimate before-build
+      env: 
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID}}
+        GIT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+        GIT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      run: |
+           ../cc-test-reporter before-build
+
+    - name: Download coverage from CI run
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          const coverageArtifactName = "jacoco-coverage";
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == coverageArtifactName;
+          })[0];
+          if (!matchArtifact) {
+            console.error(artifacts);
+            throw new Error("did not find expected artifact `" + artifactName + "`");
+          }
+          var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/coverage-artifact.zip', Buffer.from(download.data));
+
+    - run: unzip -j coverage-artifact.zip jacocoTestReport.xml -d ..
+
+    - name: codeclimate after-build
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID}}
+        GIT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+        GIT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      run: |
+           JACOCO_SOURCE_PATH=src/main/java ../cc-test-reporter format-coverage ../jacocoTestReport.xml --input-type jacoco --exit-code 0
+           ../cc-test-reporter upload-coverage

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,39 +1,28 @@
-name: Java SDK CI
+name: PayPay Java SDK CI
 
 on: [push,pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CC_TEST_REPORTER_ID: 7603e87a55419aadb1e918a8c959fac1b43d45ef92be67a8e595015f2ff92882
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up openjdk
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: register repo token
-        run: |
-          echo repo_token: ${COVERALLS_REPO_TOKEN} > ./.coveralls.yml
-      - name: Before script
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
 
-      - name: Build, Test and upload report to Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run coverage
         run: |
           ./gradlew clean build jacocoTestReport
-          ./gradlew coveralls
 
       - name: Upload to CoPilot
         run: bash <(curl -s https://copilot.blackducksoftware.com/ci/githubactions/scripts/upload)
 
-      - name: After build script CodeClimate
-        run: |
-          JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage build/reports/jacoco/test/jacocoTestReport.xml --input-type jacoco
-          ./cc-test-reporter upload-coverage
+      - name: Upload coverage GitHub artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # Consumed by the `build-ci-target.yml` `upload-codeclimate` job.
+          name: jacoco-coverage
+          path: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Maven Central](https://img.shields.io/maven-central/v/jp.ne.paypay/paypayopa)](https://search.maven.org/artifact/jp.ne.paypay/paypayopa)
 [![javadoc](https://javadoc.io/badge2/jp.ne.paypay/paypayopa/javadoc.svg)](https://javadoc.io/doc/jp.ne.paypay/paypayopa)
 [![Build Status](https://travis-ci.org/paypay/paypayopa-sdk-java.svg?branch=master)](https://travis-ci.org/paypay/paypayopa-sdk-java)
-[![Coverage Status](https://coveralls.io/repos/github/paypay/paypayopa-sdk-java/badge.svg?branch=master)](https://coveralls.io/github/paypay/paypayopa-sdk-java?branch=master)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/paypay/paypayopa-sdk-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/paypay/paypayopa-sdk-java/context:java)
 [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/paypay/paypayopa-sdk-java/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/paypay/paypayopa-sdk-java/branches/master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/64c7339473ea7711415c/maintainability)](https://codeclimate.com/github/paypay/paypayopa-sdk-java/maintainability)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 }
 plugins {
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
 }
 
 apply plugin: 'idea'
@@ -25,14 +24,13 @@ apply plugin: 'maven'
 apply plugin: 'pmd'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'com.github.kt3k.coveralls'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 javadoc.options.encoding = 'UTF-8'
 jacocoTestReport {
     reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
+        xml.enabled = true // coverage depends on xml format report
         html.enabled = true
     }
     afterEvaluate {


### PR DESCRIPTION
The `kt3k/coveralls` gradle plugin does not support authentication with `GITHUB_TOKEN` and is currently not actively maintained.

Since we also have coverage reports from CodeClimate, I'm temporarily removing the Coveralls check until a better system can be used. The official [Coveralls GitHub Action](https://github.com/coverallsapp/github-action) does not support the Jacoco coverage format (only LCOV), and so it cannot be used immediately.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
