### PR TITLE
Add entrypoint method for v4/paymentMethods endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Title | Method | HTTP request | Description
 *PaymentApi* | [**refundPayment**](docs/PaymentApi.md#refundPayment) | **POST** /v2/refunds | Refund a payment
 *PaymentApi* | [**createPendingPayment**](docs/PendingPaymentApi.md#createPendingPayment) | **POST** /v1/requestOrder | Create a pending payment
 *PaymentApi* | [**getPaymentDetails**](docs/PendingPaymentApi.md#getPaymentDetails) | **GET** /v1/requestOrder/{merchantPaymentId} | Get payment details (Pending Payment)
+*PaymentApi* | [**getPaymentMethods**](docs/PaymentApi.md#getPaymentMethods) | **GET** /v4/paymentMethods | Get payment methods
 *PaymentApi* | [**cancelPendingOrder**](docs/PendingPaymentApi.md#cancelPendingOrder) | **DELETE** /v1/requestOrder/{merchantPaymentId} | Cancel a Pending Order
 *PaymentApi* | [**getRefundDetails**](docs/PendingPaymentApi.md#getRefundDetails) | **GET** /v2/refunds/{merchantRefundId} | Get refund details (Pending Payment)
 *PaymentApi* | [**refundPayment**](docs/PendingPaymentApi.md#refundPayment) | **POST** /v1/requestOrder/refunds | Refund a payment (Pending Payment)

--- a/docs/PaymentApi.md
+++ b/docs/PaymentApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**createQRCode**](PaymentApi.md#createQRCode) | **POST** /v2/codes | Create a Code
 [**deleteQRCode**](PaymentApi.md#deleteQRCode) | **DELETE** /v2/codes/{codeId} | Delete a Code
 [**getPaymentDetails**](PaymentApi.md#getPaymentDetails) | **GET** /v2/payments/{merchantPaymentId} | Get payment details
+[**getPaymentMethods**](PaymentApi.md#getPaymentMethods) | **GET** /v4/paymentMethods | Get payment methods
 [**getCodesPaymentDetails**](PaymentApi.md#getCodesPaymentDetails) | **GET** /v2/codes/payments/{merchantPaymentId} | Get payment details for QR code
 [**getRefundDetails**](PaymentApi.md#getRefundDetails) | **GET** /v2/refunds/{merchantRefundId} | Get refund details
 [**refundPayment**](PaymentApi.md#refundPayment) | **POST** /v2/refunds | Refund a payment
@@ -394,6 +395,42 @@ try {
  Please refer to the below document for more information :
 https://www.paypay.ne.jp/opa/doc/v1.0/direct_debit#operation/getPaymentDetails
 ```
+
+<a name="getPaymentMethods"></a>
+# **getPaymentMethods**
+> PaymentMethodsResponse getPaymentMethods(userAuthorizationId)
+
+Get payment methods
+
+Get payment methods.  **Timeout: 30s**
+
+### Example
+```java
+// Import classes:
+import jp.ne.paypay.ApiException;
+import jp.ne.paypay.api.PaymentApi;
+
+
+
+PaymentApi apiInstance = new PaymentApi(apiClient);
+
+String userAuthorizationId = "USER_AUTHORIZATION_ID"; // String
+ProductType productType = null; // Optional
+
+try {
+    PaymentMethodsResponse result = apiInstance.getPaymentMethods(userAuthorizationId, productType);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling PaymentApi#getPaymentMethods");
+    System.out.println(e.getResponseBody());
+}
+```
+
+```
+ Please refer to the below document for more information :
+https://www.paypay.ne.jp/opa/doc/v1.0/direct_debit#tag/Payment/operation/GetPaymentMethods
+```
+
 <a name="getCodesPaymentDetails"></a>
 # **getCodesPaymentDetails**
 > PaymentDetails getCodesPaymentDetails(merchantPaymentId)

--- a/src/main/java/jp/ne/paypay/api/ApiNameConstants.java
+++ b/src/main/java/jp/ne/paypay/api/ApiNameConstants.java
@@ -8,6 +8,7 @@ public class ApiNameConstants {
     public static final String CREATE_QRCODE = "v2_createDynamicQRCode";
     public static final String DELETE_QRCODE = "v2_deleteDynamicQRCode";
     public static final String GET_PAYMENT = "v2_getPaymentDetail";
+    public static final String GET_PAYMENT_METHODS = "v4_getPaymentMethods";
     public static final String GET_QR_PAYMENT = "v2_getQRPaymentDetails";
     public static final String GET_REFUND = "v2_getRefundDetails";
     public static final String REFUND_PAYMENT = "v2_createRefundPayment";

--- a/src/main/java/jp/ne/paypay/api/PaymentApi.java
+++ b/src/main/java/jp/ne/paypay/api/PaymentApi.java
@@ -14,6 +14,8 @@ import jp.ne.paypay.model.LinkQRCodeResponse;
 import jp.ne.paypay.model.NotDataResponse;
 import jp.ne.paypay.model.Payment;
 import jp.ne.paypay.model.PaymentDetails;
+import jp.ne.paypay.model.PaymentMethodsResponse;
+import jp.ne.paypay.model.ProductType;
 import jp.ne.paypay.model.QRCode;
 import jp.ne.paypay.model.QRCodeDetails;
 import jp.ne.paypay.model.Refund;
@@ -21,6 +23,10 @@ import jp.ne.paypay.model.RefundDetails;
 import jp.ne.paypay.model.RevertAuthResponse;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class PaymentApi {
     private ApiClient apiClient;
@@ -72,8 +78,7 @@ public class PaymentApi {
      */
     protected ApiResponse<NotDataResponse> cancelPaymentWithHttpInfo(String merchantPaymentId) throws ApiException {
         Call call = cancelPaymentValidateBeforeCall(merchantPaymentId);
-        Type localVarReturnType = new TypeToken<NotDataResponse>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<NotDataResponse>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CANCEL_PAYMENT);
     }
 
@@ -103,8 +108,7 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> capturePaymentAuthWithHttpInfo(Object body) throws ApiException {
         Call call = capturePaymentAuthCall(body);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CAPTURE_PAYMENT);
     }
 
@@ -145,8 +149,7 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> createPaymentWithHttpInfo(Object body, String agreeSimilarTransaction) throws ApiException {
         Call call = createPaymentValidateBeforeCall(body, agreeSimilarTransaction);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CREATE_PAYMENT);
     }
 
@@ -192,8 +195,7 @@ public class PaymentApi {
      */
     protected ApiResponse<QRCodeDetails> createQRCodeWithHttpInfo(Object body) throws ApiException {
         Call call = createQRCodeValidateBeforeCall(body);
-        Type localVarReturnType = new TypeToken<QRCodeDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<QRCodeDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CREATE_QRCODE);
     }
 
@@ -225,8 +227,7 @@ public class PaymentApi {
      */
     protected ApiResponse<NotDataResponse> deleteQRCodeWithHttpInfo(String codeId) throws ApiException {
         Call call = deleteQRCodeValidateBeforeCall(codeId);
-        Type localVarReturnType = new TypeToken<NotDataResponse>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<NotDataResponse>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.DELETE_QRCODE);
     }
 
@@ -258,12 +259,64 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> getPaymentDetailsWithHttpInfo(String merchantPaymentId) throws ApiException {
         Call call = getPaymentDetailsValidateBeforeCall(merchantPaymentId);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.GET_PAYMENT);
     }
 
+    /**
+     * Validate request parameters and build http call
+     *
+     * @param userAuthorizationId (required)
+     * @param productType (optional)
+     * @return Call
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    private Call getPaymentMethodsValidateBeforeCall(String userAuthorizationId, ProductType productType) throws ApiException {
+        // verify the required parameter 'userAuthorizationId' is set
+        if (userAuthorizationId == null)
+            throw new ApiException("Missing the required parameter 'userAuthorizationId' when calling getPaymentMethods");
 
+        List<Pair> localVarCollectionQueryParams = new ArrayList<>();
+        Map<String, String> localVarHeaderParams = new HashMap<>();
+        Map<String, Object> localVarFormParams = new HashMap<>();
+        String[] localVarAuthNames = new String[]{ApiConstants.HMAC_AUTH};
+
+        List<Pair> localVarQueryParams = new ArrayList<>(apiClient.parameterToPair("userAuthorizationId", userAuthorizationId));
+        if (productType != null)
+            localVarQueryParams.addAll(apiClient.parameterToPair("productType", productType));
+
+        return apiClient.buildCall("/v4/paymentMethods", "GET", localVarQueryParams, localVarCollectionQueryParams,
+            null, localVarHeaderParams, localVarFormParams, localVarAuthNames);
+    }
+
+    /**
+     * Get payment methods
+     * Get payment methods.  **Timeout: 30s**
+     *
+     * @param userAuthorizationId (required)
+     * @param productType (optional)
+     * @return PaymentMethodsResponse
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public PaymentMethodsResponse getPaymentMethods(String userAuthorizationId, ProductType productType) throws ApiException {
+        ApiResponse<PaymentMethodsResponse> resp = getPaymentMethodsWithHttpInfo(userAuthorizationId, productType);
+        return resp.getData();
+    }
+
+    /**
+     * Get payment methods
+     * Get payment methods.  **Timeout: 30s**
+     *
+     * @param userAuthorizationId (required)
+     * @param productType (optional)
+     * @return ApiResponse&lt;PaymentMethodsResponse&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    protected ApiResponse<PaymentMethodsResponse> getPaymentMethodsWithHttpInfo(String userAuthorizationId, ProductType productType) throws ApiException {
+        Call call = getPaymentMethodsValidateBeforeCall(userAuthorizationId, productType);
+        Type localVarReturnType = new TypeToken<PaymentMethodsResponse>() {}.getType();
+        return apiClient.execute(call, localVarReturnType, ApiNameConstants.GET_PAYMENT_METHODS);
+    }
 
     private Call getCodesPaymentDetailsValidateBeforeCall(String merchantPaymentId) throws ApiException {
         return ApiUtil.getCallObject(apiClient, "/v2/codes/payments/{merchantPaymentId}", new Pair(ApiConstants.MERCHANT_PAYMENT_ID,
@@ -293,8 +346,7 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> getCodesPaymentDetailsWithHttpInfo(String merchantPaymentId) throws ApiException {
         Call call = getCodesPaymentDetailsValidateBeforeCall(merchantPaymentId);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.GET_QR_PAYMENT);
     }
 
@@ -328,8 +380,7 @@ public class PaymentApi {
      */
     protected ApiResponse<RefundDetails> getRefundDetailsWithHttpInfo(String merchantRefundId) throws ApiException {
         Call call = getRefundDetailsValidateBeforeCall(merchantRefundId);
-        Type localVarReturnType = new TypeToken<RefundDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<RefundDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.GET_REFUND);
     }
 
@@ -361,8 +412,7 @@ public class PaymentApi {
      */
     protected ApiResponse<RefundDetails> refundPaymentWithHttpInfo(Object body) throws ApiException {
         Call call = refundPaymentValidateBeforeCall(body);
-        Type localVarReturnType = new TypeToken<RefundDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<RefundDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.REFUND_PAYMENT);
     }
 
@@ -393,8 +443,7 @@ public class PaymentApi {
      */
     protected ApiResponse<RevertAuthResponse> revertAuthWithHttpInfo(Object body) throws ApiException {
         Call call = revertAuthValidateBeforeCall(body);
-        Type localVarReturnType = new TypeToken<RevertAuthResponse>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<RevertAuthResponse>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.REVERT_AUTHORIZE);
     }
 
@@ -422,8 +471,7 @@ public class PaymentApi {
      */
     protected ApiResponse<LinkQRCodeResponse> createAccountLinkQRCodeWithHttpInfo(Object body) throws ApiException {
         Call call = createAccountLinkQrCodeCall(body);
-        Type localVarReturnType = new TypeToken<LinkQRCodeResponse>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<LinkQRCodeResponse>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CREATE_QR_SESSION);
     }
 
@@ -458,8 +506,7 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> createPaymentAuthorizationWithHttpInfo(Object body, String agreeSimilarTransaction) throws ApiException {
         Call call =  ApiUtil.postCallObject(apiClient, "/v2/payments/preauthorize", body, agreeSimilarTransaction);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.PREAUTHORIZE_PAYMENT);
     }
 
@@ -488,8 +535,7 @@ public class PaymentApi {
      */
     protected ApiResponse<PaymentDetails> createContinuousPaymentWithHttpInfo(Object body) throws ApiException {
         Call call = createContinuousPaymentCall(body);
-        Type localVarReturnType = new TypeToken<PaymentDetails>() {
-        }.getType();
+        Type localVarReturnType = new TypeToken<PaymentDetails>() {}.getType();
         return apiClient.execute(call, localVarReturnType, ApiNameConstants.CREATE_CONTINUOUS_PAYMENT);
     }
 

--- a/src/main/java/jp/ne/paypay/model/Payment.java
+++ b/src/main/java/jp/ne/paypay/model/Payment.java
@@ -350,9 +350,4 @@ public class Payment extends PaymentState {
     }
     return o.toString().replace("\n", "\n    ");
   }
-
-  
 }
-
-
-

--- a/src/main/java/jp/ne/paypay/model/PaymentMethod.java
+++ b/src/main/java/jp/ne/paypay/model/PaymentMethod.java
@@ -1,0 +1,145 @@
+package jp.ne.paypay.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+public class PaymentMethod {
+
+  @SerializedName("paymentMethodType")
+  private final String paymentMethodType = null;
+
+  @SerializedName("id")
+  private final String paymentMethodId = null;
+
+  @SerializedName("issuerName")
+  private final String issuerName = null;
+
+  @SerializedName("accountNo")
+  private final String accountNo = null;
+
+  @SerializedName("logoUrl")
+  private final String logoUrl = null;
+
+  @SerializedName("disabled")
+  private final Boolean disabled = null;
+
+  @SerializedName("underMaintenance")
+  private final Boolean underMaintenance = null;
+
+  @SerializedName("authenticated")
+  private final Boolean authenticated = null;
+
+  @SerializedName("limited")
+  private final Boolean limited = null;
+
+  @SerializedName("paymentMethodStatus")
+  private final PaymentMethodStatus paymentMethodStatus = null;
+
+  public enum PaymentMethodStatus {
+    MAINTENANCE,
+    OFF,
+    ACTIVATED,
+    APPLYING,
+    SUSPENDED,
+    EXPIRED;
+  }
+
+
+  public String getPaymentMethodType() {
+    return paymentMethodType;
+  }
+
+  public String getPaymentMethodId() {
+    return paymentMethodId;
+  }
+
+  public String getIssuerName() {
+    return issuerName;
+  }
+
+  public String getAccountNo() {
+    return accountNo;
+  }
+
+  public String getLogoUrl() {
+    return logoUrl;
+  }
+
+  public Boolean getDisabled() {
+    return disabled;
+  }
+
+  public Boolean getUnderMaintenance() {
+    return underMaintenance;
+  }
+
+  public Boolean getAuthenticated() {
+    return authenticated;
+  }
+
+  public Boolean getLimited() {
+    return limited;
+  }
+
+  public PaymentMethodStatus getPaymentMethodStatus() {
+    return paymentMethodStatus;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PaymentMethod another = (PaymentMethod) o;
+
+    return Objects.equals(this.paymentMethodType, another.paymentMethodType) &&
+      Objects.equals(this.paymentMethodId, another.paymentMethodId) &&
+      Objects.equals(this.issuerName, another.issuerName) &&
+      Objects.equals(this.accountNo, another.accountNo) &&
+      Objects.equals(this.logoUrl, another.logoUrl) &&
+      Objects.equals(this.disabled, another.disabled) &&
+      Objects.equals(this.underMaintenance, another.underMaintenance) &&
+      Objects.equals(this.authenticated, another.authenticated) &&
+      Objects.equals(this.limited, another.limited) &&
+      Objects.equals(this.paymentMethodStatus, another.paymentMethodStatus);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(paymentMethodType, paymentMethodId, issuerName,
+        accountNo, logoUrl, disabled, underMaintenance, authenticated, limited, paymentMethodStatus);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PaymentMethod {\n");
+    sb.append("    paymentMethodType: ").append(toIndentedString(paymentMethodType)).append("\n");
+    sb.append("    id: ").append(toIndentedString(paymentMethodId)).append("\n");
+    sb.append("    issuerName: ").append(toIndentedString(issuerName)).append("\n");
+    sb.append("    accountNo: ").append(toIndentedString(accountNo)).append("\n");
+    sb.append("    logoUrl: ").append(toIndentedString(logoUrl)).append("\n");
+    sb.append("    disabled: ").append(toIndentedString(disabled)).append("\n");
+    sb.append("    underMaintenance: ").append(toIndentedString(underMaintenance)).append("\n");
+    sb.append("    authenticated: ").append(toIndentedString(authenticated)).append("\n");
+    sb.append("    limited: ").append(toIndentedString(limited)).append("\n");
+    sb.append("    paymentMethodStatus: ").append(toIndentedString(paymentMethodStatus)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/src/main/java/jp/ne/paypay/model/PaymentMethodsResponse.java
+++ b/src/main/java/jp/ne/paypay/model/PaymentMethodsResponse.java
@@ -1,0 +1,114 @@
+package jp.ne.paypay.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Objects;
+
+public class PaymentMethodsResponse {
+
+    @SerializedName("resultInfo")
+    private final ResultInfo resultInfo = null;
+
+    @SerializedName("data")
+    private final Data data = null;
+
+    public ResultInfo getResultInfo() {
+        return resultInfo;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PaymentMethodsResponse paymentMethodsResponse = (PaymentMethodsResponse) o;
+        return Objects.equals(this.resultInfo, paymentMethodsResponse.resultInfo) &&
+            Objects.equals(this.data, paymentMethodsResponse.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resultInfo, data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PaymentMethodsResponse {\n");
+        sb.append("    resultInfo: ").append(toIndentedString(resultInfo)).append("\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    public class Data {
+
+        @SerializedName("walletInfo")
+        private final WalletInfo walletInfo = null;
+
+        @SerializedName("paymentMethods")
+        private final List<PaymentMethod> paymentMethods = null;
+
+        public WalletInfo getWalletInfo() {
+            return walletInfo;
+        }
+
+        public List<PaymentMethod> getPaymentMethods() {
+            return paymentMethods;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PaymentMethodsResponse.Data another = (PaymentMethodsResponse.Data) o;
+            return Objects.equals(this.walletInfo, another.walletInfo) &&
+                Objects.equals(this.paymentMethods, another.paymentMethods);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(walletInfo, paymentMethods);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class PaymentMethodsResponse.Data {\n");
+            sb.append("    walletInfo: ").append(toIndentedString(walletInfo)).append("\n");
+            sb.append("    paymentMethods: ").append(toIndentedString(paymentMethods)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        private String toIndentedString(Object o) {
+            if (o == null) {
+                return "null";
+            }
+            return o.toString().replace("\n", "\n    ");
+        }
+    }
+}

--- a/src/main/java/jp/ne/paypay/model/WalletInfo.java
+++ b/src/main/java/jp/ne/paypay/model/WalletInfo.java
@@ -1,0 +1,62 @@
+package jp.ne.paypay.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+public class WalletInfo {
+  @SerializedName("userAuthorizationId")
+  private final String userAuthorizationId = null;
+
+  @SerializedName("totalBalance")
+  private final MoneyAmount totalBalance = null;
+
+  public String getUserAuthorizationId() {
+    return userAuthorizationId;
+  }
+
+  public MoneyAmount getTotalBalance() {
+    return totalBalance;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WalletInfo another = (WalletInfo) o;
+
+    return Objects.equals(this.userAuthorizationId, another.userAuthorizationId) &&
+        Objects.equals(this.totalBalance, another.totalBalance);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userAuthorizationId, totalBalance);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class WalletInfo {\n");
+    sb.append("    userAuthorizationId: ").append(toIndentedString(userAuthorizationId)).append("\n");
+    sb.append("    totalBalance: ").append(toIndentedString(totalBalance)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}

--- a/src/test/resources/api_fixtures/v4_getPaymentMethods.json
+++ b/src/test/resources/api_fixtures/v4_getPaymentMethods.json
@@ -1,0 +1,42 @@
+{
+  "resultInfo": {
+    "code": "SUCCESS",
+    "message": "Success",
+    "codeId": "08100001"
+  },
+  "data": {
+    "walletInfo": {
+      "userAuthorizationId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "totalBalance": {
+        "amount": 0,
+        "currency": "JPY"
+      }
+    },
+    "paymentMethods": [
+      {
+        "paymentMethodType": "CREDIT_CARD",
+        "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "issuerName": "クレジットカード",
+        "accountNo": "****6666",
+        "logoUrl": null,
+        "disabled": false,
+        "underMaintenance": false,
+        "authenticated": true,
+        "limited": false,
+        "paymentMethodStatus": "ACTIVATED"
+      },
+      {
+        "paymentMethodType": "PAY_LATER_CC",
+        "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "issuerName": "PayPayあと払い",
+        "accountNo": null,
+        "logoUrl": "https://image.paypay.ne.jp/icon/payment_method_icons/paylater.png",
+        "disabled": false,
+        "underMaintenance": false,
+        "authenticated": null,
+        "limited": false,
+        "paymentMethodStatus": "ACTIVATED"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR allows users to call [v4/paymentMethods](https://www.paypay.ne.jp/opa/doc/v1.0/direct_debit#tag/Payment/operation/GetPaymentMethods) endpoint.
We will also plan to make another PR that enables users to take advantage of paymentMethods retrieved v4/paymentMethods when they make payments.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
