### PR TITLE
Migrate to CodeQL

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -21,6 +21,17 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
 
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: go, javascript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+
       - name: Run coverage
         run: |
           ./gradlew clean build jacocoTestReport

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -3,7 +3,7 @@ name: PayPay Java SDK CI
 on: [push,pull_request]
 
 jobs:
-  build:
+  code-climate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +21,27 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
 
+      - name: Run coverage
+        run: |
+          ./gradlew clean build jacocoTestReport
+
+      - name: Code Climate after-build
+        env:
+          CC_TEST_REPORTER_ID: 7498cf1d134247ce860e440046a15731b846c8e2b4d6a0111310f012d12e6fda
+        run: |
+          JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage build/reports/jacoco/test/jacocoTestReport.xml --input-type jacoco
+          ./cc-test-reporter upload-coverage
+
+  code-ql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up openjdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -32,16 +53,16 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
-      - name: Run coverage
-        run: |
-          ./gradlew clean build jacocoTestReport
+  co-pilot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up openjdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       - name: Upload to CoPilot
         run: bash <(curl -s https://copilot.blackducksoftware.com/ci/githubactions/scripts/upload)
 
-      - name: Code Climate after-build
-        env:
-          CC_TEST_REPORTER_ID: 7498cf1d134247ce860e440046a15731b846c8e2b4d6a0111310f012d12e6fda
-        run: |
-          JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage build/reports/jacoco/test/jacocoTestReport.xml --input-type jacoco
-          ./cc-test-reporter upload-coverage

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: go, javascript
+          languages: java
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2

--- a/build.gradle
+++ b/build.gradle
@@ -69,14 +69,14 @@ java {
 
 
 dependencies {
-    compile 'io.swagger:swagger-annotations:1.6.6'
+    compile 'io.swagger:swagger-annotations:1.6.10'
     compile 'com.squareup.okhttp:okhttp:2.7.5'
     compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
-    compile 'com.google.code.gson:gson:2.9.1'
-    compile ('com.auth0:java-jwt:3.19.2'){
+    compile 'com.google.code.gson:gson:2.10.1'
+    compile ('com.auth0:java-jwt:4.0.0'){
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     compile 'org.apache.commons:commons-lang3:3.12.0'
     // validation
     compile group: 'org.hibernate.validator', name: 'hibernate-validator', version: '7.0.5.Final'
@@ -84,9 +84,9 @@ dependencies {
     compile group: 'jakarta.el', name: 'jakarta.el-api', version: '4.0.0'
     compile group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'
 
-    testCompile 'org.mockito:mockito-core:4.4.0'
-    testCompile("org.junit.jupiter:junit-jupiter-engine:5.9.0")
-    testCompile("org.junit.platform:junit-platform-runner:1.9.0")
+    testCompile 'org.mockito:mockito-core:4.6.0'
+    testCompile("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testCompile("org.junit.platform:junit-platform-runner:1.9.2")
 }
 pmd{
     consoleOutput = true


### PR DESCRIPTION
According to the article, we should migrate from LTGM.com to CodeQL.
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

> therefore come to announce the plan for the gradual deprecation of LGTM.com. We will do our best to help migrate repositories that actively use LGTM.com to flag potential security issues in their pull requests. For those repositories, we will create pull requests that add a GitHub Actions workflow that runs code scanning.

[The PR](https://github.com/paypay/paypayopa-sdk-java/pull/205) was actually created by them, but we can't merge due to weird PR check status. Anyways, as we already have a Github Action for CI checks, let's add CodeQR to it.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
